### PR TITLE
Minor updates for Clojure 1.11+

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,1 @@
-{:deps {org.clojure/clojure {:mvn/version "1.10.2"}}}
+{:deps {org.clojure/clojure {:mvn/version "1.11.1"}}}

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Context based pipeline."
   :url "https://github.com/scicloj/metamorph"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
-            :url "https://www.eclipse.org/legal/epl-2.0/"}
+            :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :plugins [[lein-tools-deps "0.4.5"]]
   :middleware [lein-tools-deps.plugin/resolve-dependencies-with-deps-edn]
   :lein-tools-deps/config {:config-files [:install :user :project]})

--- a/src/scicloj/metamorph/core.clj
+++ b/src/scicloj/metamorph/core.clj
@@ -11,7 +11,7 @@
   (cond
     (keyword? op) ctx
     (not (map? ctx)) (throw (IllegalArgumentException.  (str  "Metamorph pipe functions need to return a map, but returned: " ctx "of class: " (type ctx))))
-    (not (contains? ctx :metamorph/data)) (do (println "Context after operation " op " with meta " (meta #'op) "does not contain :metamorph/data. This is likely as mistake.") ctx)
+    (not (contains? ctx :metamorph/data)) (do (println "Context after operation " op " with meta " (meta op) "does not contain :metamorph/data. This is likely as mistake.") ctx)
     :else ctx))
 
 (defn pipeline
@@ -26,8 +26,7 @@
     (fn local-pipeline
       ([] (local-pipeline {})) ;; can be called without a context
       ([ctx]
-       (let [ctx (if-not (map? ctx)
-                   {:metamorph/data ctx} ctx)] ;; if context is not a map, pack it to the map
+       (let [ctx (if-not (map? ctx) {:metamorph/data ctx} ctx)] ;; if context is not a map, pack it to the map
          (reduce (fn [curr-ctx [id op]]         ;; go through operations
                    (assert (some? op) "op cannot be nil")
                    (if (map? op) ;; map means to be merged with following operation

--- a/test/scicloj/metamorph/core_test.clj
+++ b/test/scicloj/metamorph/core_test.clj
@@ -2,8 +2,6 @@
   (:require [scicloj.metamorph.core :as sut]
             [clojure.test :as t]
             [scicloj.metamorph.protocols :as prot]))
-            
-
 
 (defn gen-rand
   [s]
@@ -11,8 +9,6 @@
     #(let [n (first @x)]
        (swap! x rest)
        n)))
-
-
 
 (defn context-operator
   [ctx]


### PR DESCRIPTION
## Context

I was just exploring the code and realized that there are some parts of the code that can be reduced if we migrate to a most recent clojure version, the main changes are the following:

- Update uuid to use random-uuid instead
- Remove ctx and op symbols from check-metamorph
- Replace true with :else as a recommended practice for cond